### PR TITLE
Add __eq__ and __hash__ to TaskInstance

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -619,6 +619,15 @@ class TaskInstance(Base):
         if state:
             self.state = state
 
+    def __key(self):
+        return (self.task_id, self.dag_id, self.execution_date)
+
+    def __eq__(self, other):
+        return  self.__key() == other.__key()
+
+    def __hash__(self):
+        return hash(self.__key())
+
     def command(
             self,
             mark_success=False,


### PR DESCRIPTION
`SchedulerJob` contains a `set` of `TaskInstance`s called `queued_tis`. `SchedulerJob.process_events` loops through `queued_tis` and tries to remove completed tasks. However, without customizing `__eq__` and `__hash__`, the following two lines have no effect, never removing elements from `queued_tis`:

```
elif ti in self.queued_tis:
    self.queued_tis.remove(ti)
````